### PR TITLE
Add 'wait' subcommand

### DIFF
--- a/client.go
+++ b/client.go
@@ -37,13 +37,16 @@ func runClient(sock string, m interface{}) error {
 	return nil
 }
 
-func RunQueueClient(sock string) error {
+func RunQueueClient(sock string, tag string) error {
 	return runClient(sock, &QueueMessage{
 		DrvPath:  os.Getenv("DRV_PATH"),
 		OutPaths: os.Getenv("OUT_PATHS"),
+		Tag:      tag,
 	})
 }
 
-func RunWaitClient(sock string) error {
-	return runClient(sock, &WaitMessage{})
+func RunWaitClient(sock string, tag string) error {
+	return runClient(sock, &WaitMessage{
+		Tag: tag,
+	})
 }

--- a/client.go
+++ b/client.go
@@ -1,31 +1,49 @@
 package main
 
 import (
-	"encoding/json"
 	"net"
 	"os"
 )
 
-func RunClient(sock string) error {
-	c, err := net.Dial("unix", sock)
-	if err != nil {
-		return err
-	}
-	defer c.Close()
-
-	m := message{}
-	m.DrvPath = os.Getenv("DRV_PATH")
-	m.OutPaths = os.Getenv("OUT_PATHS")
-
-	payload, err := json.Marshal(m)
+func runClient(sock string, m interface{}) error {
+	b, err := EncodeMessage(m)
 	if err != nil {
 		return err
 	}
 
-	_, err = c.Write(payload)
+	conn, err := net.Dial("unix", sock)
 	if err != nil {
+		return err
+	}
+
+	unixConn := conn.(*net.UnixConn)
+	defer unixConn.Close()
+
+	// Write the message and send EOF.
+	_, err = unixConn.Write(b)
+	if err != nil {
+		return err
+	}
+	if err := unixConn.CloseWrite(); err != nil {
+		return err
+	}
+
+	// Wait for remote to close the connection.
+	_, err = unixConn.Read([]byte{0})
+	if err != nil && err.Error() != "EOF" {
 		return err
 	}
 
 	return nil
+}
+
+func RunQueueClient(sock string) error {
+	return runClient(sock, &QueueMessage{
+		DrvPath:  os.Getenv("DRV_PATH"),
+		OutPaths: os.Getenv("OUT_PATHS"),
+	})
+}
+
+func RunWaitClient(sock string) error {
+	return runClient(sock, &WaitMessage{})
 }

--- a/main.go
+++ b/main.go
@@ -18,9 +18,11 @@ func main() {
 
 	queueCommand := flag.NewFlagSet("queue", flag.ExitOnError)
 	queueSockPath := queueCommand.String("socket", "", "Path to daemon socket")
+	queueTag := queueCommand.String("tag", "", "Optional tag, for use with wait")
 
 	waitCommand := flag.NewFlagSet("wait", flag.ExitOnError)
 	waitSockPath := waitCommand.String("socket", "", "Path to daemon socket")
+	waitTag := waitCommand.String("tag", "", "Optional tag to filter on")
 
 	printDefaults := func() {
 		fmt.Println(fmt.Sprintf("Usage: \"%s daemon\", \"%s queue\" \"%s wait\"", os.Args[0], os.Args[0], os.Args[0]))
@@ -61,7 +63,7 @@ func main() {
 			panic("Missing required flag socket")
 		}
 
-		err := RunQueueClient(sock)
+		err := RunQueueClient(sock, *queueTag)
 		if err != nil {
 			panic(err)
 		}
@@ -72,7 +74,7 @@ func main() {
 			panic("Missing required flag socket")
 		}
 
-		err := RunWaitClient(sock)
+		err := RunWaitClient(sock, *waitTag)
 		if err != nil {
 			panic(err)
 		}

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ func main() {
 	realHook := daemonCommand.String("hook", "", "Path to the 'real' post-build-hook")
 	retryInterval := daemonCommand.Int("retry-interval", 1, "Retry interval (in seconds)")
 	retries := daemonCommand.Int("retries", 5, "How many retries to attempt before dropping")
+	concurrency := daemonCommand.Int("concurrency", 0, "How many jobs to run in parallel (default 0 / infinite)")
 
 	queueCommand := flag.NewFlagSet("queue", flag.ExitOnError)
 	queueSockPath := queueCommand.String("socket", "", "Path to daemon socket")
@@ -55,7 +56,11 @@ func main() {
 		if hook == "" {
 			panic("Missing required flag hook")
 		}
-		RunDaemon(stderr, hook, *retryInterval, *retries)
+		RunDaemon(stderr, hook, &DaemonConfig{
+			RetryInterval: *retryInterval,
+			Retries:       *retries,
+			Concurrency:   *concurrency,
+		})
 
 	} else if queueCommand.Parsed() {
 		sock := *queueSockPath

--- a/message.go
+++ b/message.go
@@ -13,9 +13,12 @@ type envelope struct {
 type QueueMessage struct {
 	DrvPath  string `json:"DRV_PATH"`
 	OutPaths string `json:"OUT_PATHS"`
+	Tag      string `json:"TAG"`
 }
 
-type WaitMessage struct{}
+type WaitMessage struct {
+	Tag string `json:"TAG"`
+}
 
 func EncodeMessage(m interface{}) ([]byte, error) {
 	switch m := m.(type) {


### PR DESCRIPTION
This adds a `wait` subcommand to wait until the queue is idle. In addition, I've added a `--tag` option to both `queue` and `wait` so it's possible to wait on a specific set of jobs by tag.

This is useful to synchronize processes. For example, we have a build machine that uploads to a private cache, and once the build is complete, another machine is instructed to download from this cache. This allows us to wait for the queue to finish right before we send that instruction.