### PR TITLE
fix(nixos module): do not list directory

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -139,7 +139,6 @@ in
           script = ''
             set -euo pipefail
             shopt -u nullglob
-            ls -l ''${CREDENTIALS_DIRECTORY}
             # Load all credentials into env if they are in UPPER_SNAKE form.
             if [[ -n "''${CREDENTIALS_DIRECTORY:-}" ]]; then
               for file in "$CREDENTIALS_DIRECTORY"/*; do


### PR DESCRIPTION
The daemon failed to start when no credentials are provided as the environment variable `CREDENTIALS_DIRECTORY` doesn't exists.