### PR TITLE
nix: fix no-url-literals leftover

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,7 +11,7 @@ pkgs.buildGoPackage rec {
 
   meta = {
     description = "Queue and retry Nix post-build-hook";
-    homepage = https://github.com/nix-community/queued-build-hook;
+    homepage = "https://github.com/nix-community/queued-build-hook";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.adisbladis ];
   };


### PR DESCRIPTION
Fixes error encountered when building with `no-url-literals` set:

```log

       error: URL literals are disabled

       at /nix/store/ijakys15fpww8fkqykgakdjf8j3cv753-source/default.nix:14:16:

           13|     description = "Queue and retry Nix post-build-hook";
           14|     homepage = https://github.com/nix-community/queued-build-hook;
             |                ^
           15|     license = lib.licenses.mit;
```